### PR TITLE
Feature: applicant details notification filterhook

### DIFF
--- a/inc/class-awsm-job-openings-form.php
+++ b/inc/class-awsm-job-openings-form.php
@@ -624,6 +624,7 @@ class AWSM_Job_Openings_Form {
 				 * @since 1.4
 				 *
 				 * @param array $headers Additional headers
+				 * @param array $applicant_details Applicant details
 				 */
 				$headers = apply_filters(
 					'awsm_jobs_applicant_notification_mail_headers',

--- a/inc/class-awsm-job-openings-form.php
+++ b/inc/class-awsm-job-openings-form.php
@@ -632,7 +632,8 @@ class AWSM_Job_Openings_Form {
 						'from'         => sprintf( 'From: %1$s <%2$s>', $from, $from_email ),
 						'reply_to'     => 'Reply-To: ' . $reply_to,
 						'cc'           => 'Cc: ' . $applicant_cc,
-					)
+					),
+					$applicant_details
 				);
 
 				$reply_to = trim( str_replace( 'Reply-To:', '', $headers['reply_to'] ) );


### PR DESCRIPTION
As discussed in issue: #9 

Added `$applicant_details` param to the `awsm_jobs_applicant_notification_mail_headers` filter hook. This way e-mail headers can be customized accordingly.