### PR TITLE
Fix: register custom capabilities in phpcs.xml and align minimum supported WP version

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,7 +2,7 @@
 <ruleset name="WP Job Openings">
     <description>WP Job Openings coding standard.</description>
 
-    <config name="minimum_supported_wp_version" value="4.8" />
+    <config name="minimum_supported_wp_version" value="6.0" />
     <!-- Check for cross-version support for PHP 5.6 and higher. -->
     <config name="testVersion" value="5.6-" />
 
@@ -32,6 +32,37 @@
 		<properties>
 			<property name="customAutoEscapedFunctions" type="array">
 				<element value="awsm_jobs_paginate_links" />
+			</property>
+		</properties>
+	</rule>
+
+	<!-- Custom capabilities/roles registered by this plugin (inc/class-awsm-job-openings-core.php)
+	     and by the sibling Pro Pack add-on (hiring_panelist, via its own "Hiring Panelist" role). -->
+	<rule ref="WordPress.WP.Capabilities">
+		<properties>
+			<property name="custom_capabilities" type="array">
+				<element value="edit_jobs" />
+				<element value="delete_jobs" />
+				<element value="edit_applications" />
+				<element value="delete_applications" />
+				<element value="edit_published_jobs" />
+				<element value="delete_published_jobs" />
+				<element value="publish_jobs" />
+				<element value="edit_published_applications" />
+				<element value="delete_published_applications" />
+				<element value="publish_applications" />
+				<element value="edit_others_jobs" />
+				<element value="read_private_jobs" />
+				<element value="delete_private_jobs" />
+				<element value="delete_others_jobs" />
+				<element value="edit_private_jobs" />
+				<element value="edit_others_applications" />
+				<element value="read_private_applications" />
+				<element value="delete_private_applications" />
+				<element value="delete_others_applications" />
+				<element value="edit_private_applications" />
+				<element value="manage_awsm_jobs" />
+				<element value="hiring_panelist" />
 			</property>
 		</properties>
 	</rule>


### PR DESCRIPTION
## Summary
- Registers this plugin's custom capabilities (`edit_jobs`, `manage_awsm_jobs`, `edit_others_applications`, etc.) and the Pro Pack `hiring_panelist` capability with the `WordPress.WP.Capabilities` sniff, so PHPCS stops flagging them as "unknown capability" (41 false-positive warnings removed).
- Raises `minimum_supported_wp_version` in phpcs.xml from the stale `4.8` to `6.0`, matching the plugin's actual `Requires at least: 6.0` header — this affects which deprecated-function/parameter sniffs apply.

## Why
`phpcs.xml` predates several of the plugin's own custom capabilities and the Pro Pack add-on's `hiring_panelist` capability, so every `current_user_can()` call using them was flagged as a possible typo. The WP-version floor was also six major versions behind the plugin's real requirement, which meant the ruleset wasn't checking deprecations introduced between 4.8 and 6.0.

## Changes
- `phpcs.xml` only — no PHP logic touched.

## Test Plan
- [x] `composer install` (fresh vendor/) then `vendor/bin/phpcs --report=summary .` — before: 200 warnings/0 errors; after: 159 warnings/0 errors (41 capability warnings eliminated, no new ones introduced)
- [x] Confirmed raising `minimum_supported_wp_version` to 6.0 surfaces **zero** new deprecated-function warnings — codebase already clean against a 6.0+ baseline
- [x] Reviewed diff — change is scoped entirely to `phpcs.xml`; no runtime PHP files touched, so no functional/UI regression risk
- [x] Verified plugin still activates cleanly and job listing archive / admin screens load (`http://localhost/testwp/`) — expected, since no executable code changed