### PR TITLE
Fix: resolve all 83 nonce-verification warnings with reviewed, scoped ignores

### DIFF
--- a/admin/class-awsm-job-openings-info.php
+++ b/admin/class-awsm-job-openings-info.php
@@ -34,7 +34,7 @@ class AWSM_Job_Openings_Info {
 			return;
 		}
 		delete_transient( '_awsm_activation_redirect' );
-		if ( is_network_admin() || isset( $_GET['activate-multi'] ) ) {
+		if ( is_network_admin() || isset( $_GET['activate-multi'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
 		wp_safe_redirect( add_query_arg( array( 'page' => 'awsm-jobs-setup' ), admin_url( 'edit.php?post_type=awsm_job_openings' ) ) );
@@ -229,7 +229,8 @@ class AWSM_Job_Openings_Info {
 				} else {
 					$is_page = $screen->id;
 				}
-				// Check if page is the setup page.
+				// Check if page is the setup page. Read-only admin-screen routing; no state mutation.
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				if ( isset( $_GET['page'] ) && $_GET['page'] === 'awsm-jobs-setup' ) {
 					$is_page = false;
 				}

--- a/admin/class-awsm-job-openings-meta.php
+++ b/admin/class-awsm-job-openings-meta.php
@@ -13,6 +13,10 @@ class AWSM_Job_Openings_Meta {
 		add_action( 'add_meta_boxes', array( $this, 'awsm_register_meta_boxes' ) );
 		add_action( 'admin_menu', array( $this, 'remove_meta_boxes' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'dequeue_autosave' ) );
+		// Read-only routing: decides which handler to hook, nothing else. Each handler itself
+		// requires the 'edit_others_applications' capability and its own per-download nonce
+		// (attached_file_download_handler()) before it does anything with the request.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['awsm_action'] ) ) {
 			if ( $_GET['awsm_action'] === 'download_resume' ) {
 				add_action( 'plugins_loaded', array( $this, 'download_resume_handle' ) );
@@ -20,6 +24,7 @@ class AWSM_Job_Openings_Meta {
 				add_action( 'plugins_loaded', array( $this, 'download_file_handle' ) );
 			}
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 		add_action( 'awsm_job_applicant_profile_details_resume_preview', array( $this, 'docs_viewer_handle' ) );
 		add_filter( 'post_row_actions', array( $this, 'awsm_job_application_row_actions_label' ), 10, 2 );
 		add_filter( 'wp_untrash_post_status', array( $this, 'awsm_job_application_restore_post_to_previous_status' ), 10, 3 );
@@ -59,7 +64,7 @@ class AWSM_Job_Openings_Meta {
 		// values into the legacy form the block editor resubmits afterward —
 		// which is exactly what was wiping the REST-saved Job Expiry values on
 		// every save. See use_block_editor_for_post() in wp-includes/post.php.
-		$is_classic_editor_context = ! use_block_editor_for_post( $post ) && ! isset( $_GET['meta-box-loader'] );
+		$is_classic_editor_context = ! use_block_editor_for_post( $post ) && ! isset( $_GET['meta-box-loader'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		if ( $action === 'edit' ) {
 			// The block editor gets a native Gutenberg panel (see
@@ -398,7 +403,10 @@ class AWSM_Job_Openings_Meta {
 	}
 
 	public function download_file_handle() {
-		$suffix = isset( $_GET['attachment_label'] ) ? '-' . $_GET['attachment_label'] : '';
+		// Read-only: attached_file_download_handler() requires the 'edit_others_applications'
+		// capability and its own per-download nonce before this suffix is ever used; it's also
+		// passed through sanitize_title() there before reaching the Content-Disposition header.
+		$suffix = isset( $_GET['attachment_label'] ) ? '-' . sanitize_text_field( wp_unslash( $_GET['attachment_label'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$this->attached_file_download_handler( 'file', $suffix );
 	}
 

--- a/admin/class-awsm-job-openings-overview.php
+++ b/admin/class-awsm-job-openings-overview.php
@@ -70,6 +70,8 @@ class AWSM_Job_Openings_Overview {
 
 	public function redirect_to_overview() {
 		global $pagenow;
+		// Read-only admin-screen routing; no state mutation.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $pagenow ) && $pagenow === 'admin.php' && isset( $_GET['page'] ) && $_GET['page'] === self::$menu_slug ) {
 			wp_safe_redirect( add_query_arg( array( 'page' => self::$menu_slug ), admin_url( 'edit.php?post_type=awsm_job_openings' ) ) );
 			exit;

--- a/admin/templates/base.php
+++ b/admin/templates/base.php
@@ -4,7 +4,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 	do_action( 'before_awsm_job_settings_init' );
 
-	$tab_menus   = AWSM_Job_Openings_Settings::settings_tab_menus();
+	$tab_menus = AWSM_Job_Openings_Settings::settings_tab_menus();
+	// Read-only tab selection for this settings screen; no state mutation. sanitize_title() also
+	// strips '.' and '/', so $current_tab can't be used to traverse outside the templates directory
+	// when it's used to build a file path below.
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	$current_tab = isset( $_GET['tab'] ) ? sanitize_title( $_GET['tab'] ) : 'general';
 
 ?>

--- a/admin/templates/meta/applicant-single.php
+++ b/admin/templates/meta/applicant-single.php
@@ -118,7 +118,8 @@ do_action( 'awsm_job_applicant_mb_init', $post->ID );
 				 */
 				do_action( 'awsm_job_application_edit' );
 			?>
-			<?php if ( ! isset( $_GET['application'] ) || $_GET['application'] !== 'edit' ) : ?>
+			<?php // Read-only display-mode toggle for this admin screen; no state mutation. ?>
+		<?php if ( ! isset( $_GET['application'] ) || $_GET['application'] !== 'edit' ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended ?>
 				<div class="application-main-cnt-tab-sec">
 					<!-- Tabs Navigation -->
 					<ul class="application-main-tab">

--- a/inc/class-awsm-job-openings-block.php
+++ b/inc/class-awsm-job-openings-block.php
@@ -181,9 +181,12 @@ class AWSM_Job_Openings_Block {
 		if ( ! empty( $filters ) ) {
 			foreach ( $filters as $filter ) {
 				$current_filter_key = str_replace( '-', '__', $filter ) . '_spec';
+				// Read-only listing filter reflected from the URL; no state mutation, so no nonce is needed here.
+				// phpcs:disable WordPress.Security.NonceVerification.Recommended
 				if ( isset( $_GET[ $current_filter_key ] ) ) {
 					$query_args[ $filter ] = sanitize_title( $_GET[ $current_filter_key ] );
 				}
+				// phpcs:enable WordPress.Security.NonceVerification.Recommended
 			}
 		}
 		return $query_args;
@@ -499,6 +502,10 @@ class AWSM_Job_Openings_Block {
 			$attrs['lang'] = $current_lang;
 		}
 
+		// Read-only reflection of the current URL's query args into data-* attributes (sanitized
+		// per key/value below, escaped on output in awsm_block_jobs_data_attrs()); no state mutation,
+		// so no nonce is needed here.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['jq'] ) ) {
 			$attrs['search'] = sanitize_text_field( $_GET['jq'] );
 		}
@@ -522,6 +529,7 @@ class AWSM_Job_Openings_Block {
 				$attrs[ $sanitized_key ] = sanitize_text_field( $value );
 			}
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		if ( is_tax() ) {
 			$q_obj             = get_queried_object();
@@ -732,7 +740,8 @@ class AWSM_Job_Openings_Block {
 		$uid = isset( $block_atts['uid'] ) ? '-' . $block_atts['uid'] : '';
 
 		if ( $enable_search === 'enable' ) {
-			$search_query = isset( $_GET['jq'] ) ? sanitize_text_field( $_GET['jq'] ) : '';
+			// Read-only reflection of the current search term back into the form field; no nonce needed.
+			$search_query = isset( $_GET['jq'] ) ? sanitize_text_field( $_GET['jq'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			/**
 			 * Filters the search field placeholder text.
 			 *
@@ -820,10 +829,13 @@ class AWSM_Job_Openings_Block {
 					foreach ( $terms as $term ) {
 						$selected = '';
 						$get_key  = str_replace( '-', '__', $taxonomy ) . '_spec';
+						// Read-only reflection of the URL's selected filter terms; no nonce needed.
+						// phpcs:disable WordPress.Security.NonceVerification.Recommended
 						if ( isset( $_GET[ $get_key ] ) && is_string( $_GET[ $get_key ] ) ) {
 							// URL param takes priority over block preselection (user's explicit choice).
 							$selected_specs = explode( ',', sanitize_text_field( wp_unslash( $_GET[ $get_key ] ) ) );
 							$selected_specs = array_filter( array_map( 'sanitize_title', array_map( 'trim', $selected_specs ) ) );
+							// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 							if ( in_array( $term->slug, $selected_specs, true ) ) {
 								$selected = ' selected';
@@ -1012,7 +1024,8 @@ class AWSM_Job_Openings_Block {
 		}
 
 		if ( $enable_search === 'enable' ) {
-			$search_query     = isset( $_GET['jq'] ) ? sanitize_text_field( $_GET['jq'] ) : '';
+			// Read-only reflection of the current search term back into the form field; no nonce needed.
+			$search_query     = isset( $_GET['jq'] ) ? sanitize_text_field( $_GET['jq'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$placeholder_text = apply_filters( 'awsm_jobs_block_search_field_side_placeholder', $placeholder_search ? $placeholder_search : $default_text );
 
 			$search_icon = '<span class="awsm-job-search-btn awsm-b-job-search-btn awsm-job-search-icon-wrapper awsm-b-job-search-icon-wrapper"><i class="awsm-job-icon-search awsm-b-job-icon-search"></i></span><span class="awsm-job-search-close-btn awsm-b-job-search-close-btn awsm-job-search-icon-wrapper awsm-b-job-search-icon-wrapper awsm-b-job-hide"><i class="awsm-job-icon-close-circle awsm-b-job-icon-close-circle"></i></span>';
@@ -1042,10 +1055,13 @@ class AWSM_Job_Openings_Block {
 						foreach ( $terms as $term ) {
 								$selected = '';
 								$get_key  = str_replace( '-', '__', $taxonomy ) . '_spec';
+							// Read-only reflection of the URL's selected filter terms; no nonce needed.
+							// phpcs:disable WordPress.Security.NonceVerification.Recommended
 							if ( isset( $_GET[ $get_key ] ) && is_string( $_GET[ $get_key ] ) ) {
 								// URL param takes priority over block preselection (user's explicit choice).
 								$selected_specs = explode( ',', sanitize_text_field( wp_unslash( $_GET[ $get_key ] ) ) );
 								$selected_specs = array_filter( array_map( 'sanitize_title', array_map( 'trim', $selected_specs ) ) );
+								// phpcs:enable WordPress.Security.NonceVerification.Recommended
 								if ( in_array( $term->slug, $selected_specs, true ) ) {
 									$selected = ' selected';
 								}

--- a/inc/class-awsm-job-openings-core.php
+++ b/inc/class-awsm-job-openings-core.php
@@ -392,8 +392,10 @@ class AWSM_Job_Openings_Core {
 			2  => __( 'Custom field updated.', 'default' ),
 			3  => __( 'Custom field deleted.', 'default' ),
 			4  => __( 'Job listing updated.', 'wp-job-openings' ),
+			// Read-only display of which revision core just restored; the restore action itself is
+			// core's own nonce-checked request, so no nonce is needed for this display-only read.
 			/* translators: %s: date and time of the revision */
-			5  => isset( $_GET['revision'] ) ? sprintf( __( 'Job listing restored to revision from %s.', 'wp-job-openings' ), wp_post_revision_title( intval( $_GET['revision'] ), false ) ) : false,
+			5  => isset( $_GET['revision'] ) ? sprintf( __( 'Job listing restored to revision from %s.', 'wp-job-openings' ), wp_post_revision_title( intval( $_GET['revision'] ), false ) ) : false, // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			6  => __( 'Job listing published.', 'wp-job-openings' ) . $view_post_link_html,
 			7  => __( 'Job listing saved.', 'wp-job-openings' ),
 			8  => __( 'Job listing submitted.', 'wp-job-openings' ) . $preview_post_link_html,
@@ -408,8 +410,10 @@ class AWSM_Job_Openings_Core {
 			2  => __( 'Custom field updated.', 'default' ),
 			3  => __( 'Custom field deleted.', 'default' ),
 			4  => __( 'Application updated.', 'wp-job-openings' ),
+			// Read-only display of which revision core just restored; the restore action itself is
+			// core's own nonce-checked request, so no nonce is needed for this display-only read.
 			/* translators: %s: date and time of the revision */
-			5  => isset( $_GET['revision'] ) ? sprintf( __( 'Application restored to revision from %s.', 'wp-job-openings' ), wp_post_revision_title( intval( $_GET['revision'] ), false ) ) : false,
+			5  => isset( $_GET['revision'] ) ? sprintf( __( 'Application restored to revision from %s.', 'wp-job-openings' ), wp_post_revision_title( intval( $_GET['revision'] ), false ) ) : false, // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			6  => __( 'Application published.', 'wp-job-openings' ),
 			7  => __( 'Application saved.', 'wp-job-openings' ),
 			8  => __( 'Application submitted.', 'wp-job-openings' ),

--- a/inc/class-awsm-job-openings-filters.php
+++ b/inc/class-awsm-job-openings-filters.php
@@ -31,9 +31,12 @@ class AWSM_Job_Openings_Filters {
 		if ( ! empty( $filters ) ) {
 			foreach ( $filters as $filter ) {
 				$current_filter_key = str_replace( '-', '__', $filter ) . self::$filter_suffix;
+				// Read-only listing filter reflected from the URL; no state mutation, so no nonce is needed here.
+				// phpcs:disable WordPress.Security.NonceVerification.Recommended
 				if ( isset( $_GET[ $current_filter_key ] ) ) {
 					$query_args[ $filter ] = sanitize_title( $_GET[ $current_filter_key ] );
 				}
+				// phpcs:enable WordPress.Security.NonceVerification.Recommended
 			}
 		}
 		return $query_args;
@@ -68,7 +71,8 @@ class AWSM_Job_Openings_Filters {
 		$uid = isset( $shortcode_atts['uid'] ) ? '-' . $shortcode_atts['uid'] : '';
 
 		if ( $enable_search === 'enable' ) {
-			$search_query = isset( $_GET['jq'] ) ? $_GET['jq'] : '';
+			// Read-only reflection of the current search term back into the form field; no nonce needed.
+			$search_query = isset( $_GET['jq'] ) ? sanitize_text_field( wp_unslash( $_GET['jq'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			/**
 			 * Filters the search field placeholder text.
 			 *
@@ -313,7 +317,7 @@ class AWSM_Job_Openings_Filters {
 	}
 
 	public function awsm_posts_filters() {
-        // phpcs:disable WordPress.Security.NonceVerification.Missing
+        // phpcs:disable WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended
 		$filters = $shortcode_atts = array(); // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found
 
 		$filter_action = isset( $_POST['action'] ) ? $_POST['action'] : '';

--- a/inc/template-functions-block.php
+++ b/inc/template-functions-block.php
@@ -66,6 +66,8 @@ if ( ! function_exists( 'awsm_block_jobs_query' ) ) {
 			}
 		}
 
+		// Read-only listing search/filter args reflected from the URL; no state mutation, so no nonce is needed here.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['jq'] ) && $_GET['jq'] !== '' ) {
 			$search_job = sanitize_text_field( wp_unslash( $_GET['jq'] ) );
 		}
@@ -76,12 +78,13 @@ if ( ! function_exists( 'awsm_block_jobs_query' ) ) {
 
 				// Check if filter exists in URL ($_GET), else use stored option
 				if ( isset( $_GET[ $current_filter_key ] ) && ! empty( $_GET[ $current_filter_key ] ) ) {
-					$term_slugs = explode( ',', sanitize_text_field( $_GET[ $current_filter_key ] ) );
+					$term_slugs = explode( ',', sanitize_text_field( wp_unslash( $_GET[ $current_filter_key ] ) ) );
 				} else {
 					// Fallback to stored option if URL parameter is missing
 					$saved_terms = get_option( 'awsm_jobs_default_' . $filter, '' ); // Modify key accordingly
 					$term_slugs  = ! empty( $saved_terms ) ? explode( ',', $saved_terms ) : array();
 				}
+				// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 				if ( ! empty( $term_slugs ) ) {
 					$query_args[ $filter ] = array();

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -46,6 +46,8 @@ if ( ! function_exists( 'awsm_jobs_query' ) ) {
 
 		$search_job = '';
 
+		// Read-only listing search/filter args reflected from the URL; no state mutation, so no nonce is needed here.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['jq'] ) && $_GET['jq'] !== '' ) {
 			$search_job = sanitize_text_field( wp_unslash( $_GET['jq'] ) );
 		}
@@ -54,11 +56,12 @@ if ( ! function_exists( 'awsm_jobs_query' ) ) {
 			foreach ( $filters as $filter ) {
 				$current_filter_key = str_replace( '-', '__', $filter ) . $filter_suffix;
 				if ( isset( $_GET[ $current_filter_key ] ) && ! empty( $_GET[ $current_filter_key ] ) ) {
-					$term_slugs = explode( ',', sanitize_text_field( $_GET[ $current_filter_key ] ) );
+					$term_slugs = explode( ',', sanitize_text_field( wp_unslash( $_GET[ $current_filter_key ] ) ) );
 				} else {
 					$saved_terms = get_option( 'awsm_jobs_default_' . $filter, '' ); // Modify key accordingly
 					$term_slugs  = ! empty( $saved_terms ) ? explode( ',', $saved_terms ) : array();
 				}
+				// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 				if ( ! empty( $term_slugs ) ) {
 					$query_args[ $filter ] = array();
@@ -228,9 +231,10 @@ if ( ! function_exists( 'awsm_jobs_paginate_links' ) ) {
 	function awsm_jobs_paginate_links( $query, $shortcode_atts = array() ) {
 		$is_homepage = is_front_page() || is_home();
 
-		// phpcs:disable WordPress.Security.NonceVerification.Missing
+		// Read-only pagination state reflected from the request; no state mutation, so no nonce is needed here.
+		// phpcs:disable WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_POST['paged'] ) ) {
-			$current = absint( $_POST['paged'] );// phpcs:disable WordPress.Security.NonceVerification.Missing
+			$current = absint( $_POST['paged'] );
 		} elseif ( $is_homepage ) {
 				$current = get_query_var( 'page' ) ? absint( get_query_var( 'page' ) ) : 1;
 		} else {
@@ -241,11 +245,10 @@ if ( ! function_exists( 'awsm_jobs_paginate_links' ) ) {
 		$max_num_pages = isset( $query->max_num_pages ) ? $query->max_num_pages : 1;
 		$base_url      = get_pagenum_link();
 
-		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		if ( isset( $_POST['awsm_pagination_base'] ) ) {
-			$base_url = $_POST['awsm_pagination_base'];
+			$base_url = sanitize_text_field( wp_unslash( $_POST['awsm_pagination_base'] ) );
 		}
-		// phpcs:enable
+		// phpcs:enable WordPress.Security.NonceVerification.Missing, WordPress.Security.NonceVerification.Recommended
 		$args               = array(
 			'base'    => esc_url_raw( add_query_arg( $page_var, '%#%', $base_url ) ),
 			'format'  => '',
@@ -302,16 +305,20 @@ if ( ! function_exists( 'awsm_no_jobs_msg' ) ) {
 		$job_spec      = array();
 		$search_job    = '';
 
+		// Read-only reflection of the current filter/search state to decide which "no jobs" message to
+		// show; no state mutation, so no nonce is needed here.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( ! empty( $_GET ) ) {
 			foreach ( $_GET as $key => $value ) {
 				if ( substr( $key, -strlen( $filter_suffix ) ) === $filter_suffix && $value !== '' ) {
-					$job_spec[ $key ] = sanitize_text_field( $value );
+					$job_spec[ $key ] = sanitize_text_field( wp_unslash( $value ) );
 				}
 			}
 			if ( isset( $_GET['jq'] ) && $_GET['jq'] !== '' ) {
 				$search_job = sanitize_text_field( wp_unslash( $_GET['jq'] ) );
 			}
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		if ( ! empty( $job_spec ) || ! empty( $search_job ) ) {
 			echo esc_html__( 'Sorry! No jobs to show.', 'wp-job-openings' );

--- a/wp-job-openings.php
+++ b/wp-job-openings.php
@@ -1214,13 +1214,16 @@ class AWSM_Job_Openings {
 
 	public function awsm_admin_filtering_posts() {
 		global $typenow;
+		// Read-only admin list-table filter UI (mirrors WP core's own GET-based list filters);
+		// no state mutation, so no nonce is needed here.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( $typenow === 'awsm_job_application' ) {
 			$jobs_post_filter = '';
 			if ( isset( $_GET['awsm_filter_posts'] ) ) {
 				$jobs_post_filter = intval( $_GET['awsm_filter_posts'] );
 			}
-			$date_range_from = ( isset( $_GET['awsm_filter_by_date_from'] ) && $_GET['awsm_filter_by_date_from'] ) ? $_GET['awsm_filter_by_date_from'] : '';
-			$date_range_to   = ( isset( $_GET['awsm_filter_by_date_to'] ) && $_GET['awsm_filter_by_date_to'] ) ? $_GET['awsm_filter_by_date_to'] : '';
+			$date_range_from = ( isset( $_GET['awsm_filter_by_date_from'] ) && $_GET['awsm_filter_by_date_from'] ) ? sanitize_text_field( wp_unslash( $_GET['awsm_filter_by_date_from'] ) ) : '';
+			$date_range_to   = ( isset( $_GET['awsm_filter_by_date_to'] ) && $_GET['awsm_filter_by_date_to'] ) ? sanitize_text_field( wp_unslash( $_GET['awsm_filter_by_date_to'] ) ) : '';
 
 			$custom_posts = array(
 				'posts_per_page'   => -1,
@@ -1247,19 +1250,23 @@ class AWSM_Job_Openings {
 			echo '<input type="text" class="awsm-application-date-filter" id="awsm_application_date_filter_to" name="awsm_filter_by_date_to" placeholder="' . esc_attr__( 'Date To', 'wp-job-openings' ) . '" value="' . esc_attr( $date_range_to ) . '" />';
 
 			$pro_spec_filter   = isset( $_GET['awsm_job_admin_filter'] ) ? array_filter( (array) $_GET['awsm_job_admin_filter'] ) : array();
-			$pro_filled_filter = isset( $_GET['awsm_filled_jobs_filter'] ) ? sanitize_text_field( $_GET['awsm_filled_jobs_filter'] ) : '';
+			$pro_filled_filter = isset( $_GET['awsm_filled_jobs_filter'] ) ? sanitize_text_field( wp_unslash( $_GET['awsm_filled_jobs_filter'] ) ) : '';
 			$has_filters       = ! empty( $jobs_post_filter ) || ! empty( $date_range_from ) || ! empty( $date_range_to ) || ! empty( $pro_spec_filter ) || ! empty( $pro_filled_filter );
 			if ( $has_filters ) {
 				echo '<a href="' . esc_url( admin_url( 'edit.php?post_type=awsm_job_application' ) ) . '" id="awsm-clear-filters" class="button awsm-clr-flt-btn">' . esc_html__( 'Clear Filter', 'wp-job-openings' ) . '</a>';
 			}
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 	}
 
 	public function awsm_admin_filter_posts( $query ) {
 		global $pagenow;
+		// Read-only admin list-table query filtering driven by the GET-based filter UI above;
+		// no state mutation, so no nonce is needed here.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		$type = 'awsm_job_application';
 		if ( isset( $_GET['post_type'] ) ) {
-			$type = $_GET['post_type'];
+			$type = sanitize_text_field( wp_unslash( $_GET['post_type'] ) );
 		}
 		if ( $type === 'awsm_job_application' && is_admin() && $pagenow === 'edit.php' && isset( $_GET['awsm_filter_posts'] ) && $query->is_main_query() ) {
 			$meta_value = intval( $_GET['awsm_filter_posts'] );
@@ -1269,8 +1276,8 @@ class AWSM_Job_Openings {
 			}
 		}
 
-		$date_from = ( isset( $_GET['awsm_filter_by_date_from'] ) && ! empty( $_GET['awsm_filter_by_date_from'] ) ) ? sanitize_text_field( $_GET['awsm_filter_by_date_from'] ) : '';
-		$date_to   = ( isset( $_GET['awsm_filter_by_date_to'] ) && ! empty( $_GET['awsm_filter_by_date_to'] ) ) ? sanitize_text_field( $_GET['awsm_filter_by_date_to'] ) : '';
+		$date_from = ( isset( $_GET['awsm_filter_by_date_from'] ) && ! empty( $_GET['awsm_filter_by_date_from'] ) ) ? sanitize_text_field( wp_unslash( $_GET['awsm_filter_by_date_from'] ) ) : '';
+		$date_to   = ( isset( $_GET['awsm_filter_by_date_to'] ) && ! empty( $_GET['awsm_filter_by_date_to'] ) ) ? sanitize_text_field( wp_unslash( $_GET['awsm_filter_by_date_to'] ) ) : '';
 
 		if ( $type === 'awsm_job_application' && is_admin() && $pagenow === 'edit.php' && $query->is_main_query() && ( ! empty( $date_from ) || ! empty( $date_to ) ) ) {
 			$date_query = array( 'inclusive' => true );
@@ -1284,6 +1291,7 @@ class AWSM_Job_Openings {
 
 			$query->query_vars['date_query'] = array( $date_query );
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 	}
 
 	public function awsm_job_month_dropdown( $months, $post_type ) {
@@ -1484,6 +1492,9 @@ class AWSM_Job_Openings {
 
 		wp_enqueue_script( 'awsm-job-scripts', AWSM_JOBS_PLUGIN_URL . '/assets/js/script.min.js', array( 'jquery' ), AWSM_JOBS_PLUGIN_VERSION, true );
 
+		// Read-only reflection of the current search term into the localized script data; no state
+		// mutation, so no nonce is needed here.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		$enable_search = get_option( 'awsm_enable_job_search' ) === 'enable' && isset( $_GET['jq'] );
 
 		global $post;
@@ -1491,7 +1502,7 @@ class AWSM_Job_Openings {
 		$localized_script_data = array(
 			'ajaxurl'            => admin_url( 'admin-ajax.php' ),
 			'is_tax_archive'     => is_tax(),
-			'is_search'          => $enable_search ? sanitize_text_field( $_GET['jq'] ) : '',
+			'is_search'          => $enable_search ? sanitize_text_field( wp_unslash( $_GET['jq'] ) ) : '',
 			'job_id'             => is_singular( 'awsm_job_openings' ) ? $post->ID : 0,
 			'wp_max_upload_size' => ( wp_max_upload_size() ) ? ( wp_max_upload_size() ) : 0,
 			'deep_linking'       => array(
@@ -1515,6 +1526,7 @@ class AWSM_Job_Openings {
 			'block_nonce'        => wp_create_nonce( 'awsm_block_ajax' ),
 			'view_count_nonce'   => wp_create_nonce( 'awsm_view_count_nonce' ),
 		);
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 		/**
 		 * Filters the public script localized data.
 		 *
@@ -2307,13 +2319,17 @@ class AWSM_Job_Openings {
 			$attrs['lang'] = $current_lang;
 		}
 
+		// Read-only reflection of the current URL's search/sort state into data-* attributes
+		// (escaped on output in awsm_jobs_data_attrs()); no state mutation, so no nonce is needed here.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['jq'] ) ) {
-			$attrs['search'] = sanitize_text_field( $_GET['jq'] );
+			$attrs['search'] = sanitize_text_field( wp_unslash( $_GET['jq'] ) );
 		}
 
 		if ( isset( $_GET['sort'] ) ) {
-			$attrs['sort'] = $_GET['sort'];
+			$attrs['sort'] = sanitize_text_field( wp_unslash( $_GET['sort'] ) );
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		if ( isset( $shortcode_atts['loadmore'] ) && $shortcode_atts['loadmore'] === 'no' ) {
 				$attrs['loadmore'] = 'no';


### PR DESCRIPTION
## Summary
Every `WordPress.Security.NonceVerification.Recommended` warning in the codebase (83 total, across 11 files) was individually reviewed against this plugin's documented security model. All of them are read-only listing/filter/display code paths — URL-driven search, sort, taxonomy filters, pagination, admin-screen routing, revision-restore messages — with no state mutation, so a nonce adds CSRF friction with no actual security benefit (CSRF protects state-changing requests).

Two existing `phpcs:disable` comments (`inc/class-awsm-job-openings-filters.php`, `inc/class-awsm-job-openings-block.php`) targeted the now-stale `NonceVerification.Missing` sniff code instead of the `.Recommended` code this WPCS version actually emits — that mismatch is why so many warnings had quietly reappeared in files that were supposedly already covered.

While reviewing each site, I also fixed several **inconsistently-unsanitized reads** sitting right next to already-sanitized sibling code doing the exact same thing — missing `sanitize_text_field()`/`wp_unslash()` on search, sort, and date-range filter values in `wp-job-openings.php` and `admin/class-awsm-job-openings-meta.php`. None were exploitable (each is either compared against a known string, cast to int, or escaped with `esc_attr()`/`esc_url()` at output), but the fixes bring every site up to the same standard as its neighbors.

## Why
No functional change — these are all confirmed-safe reads. This closes out the largest single category from a full repo-wide PHPCS/security review (83 of ~200 total warnings), and removes noise that was masking genuinely new findings in future PHPCS runs.

## Test Plan
- [x] `php -l` on all 11 touched files — no syntax errors
- [x] `vendor/bin/phpcs --report=source .` — 0 instances of `NonceVerification.Recommended` remain repo-wide (was 83), 0 errors, no new warnings introduced
- [x] Caught and fixed a self-introduced regression during this work: inserting an explanatory comment between an existing `/* translators: */` comment and its `sprintf()` call broke `WordPress.WP.I18n.MissingTranslatorsComment` detection in `inc/class-awsm-job-openings-core.php` — reordered so the translators comment stays immediately above the code it documents
- [x] Live-exercised `AWSM_Job_Openings::get_job_listing_view_class()`'s sibling functions `get_job_listing_data_attrs()` / `awsm_jobs_data_attrs()` by requesting `?post_type=awsm_job_openings&jq=engineer&sort=date` against a real WordPress install — confirmed `data-search="engineer"` and `data-sort="date"` render correctly and escaped
- [x] Live-exercised `AWSM_Job_Openings::awsm_admin_filtering_posts()` and `awsm_admin_filter_posts()` (the admin applications list-table date/job filters) with simulated `$_GET` values against a real WordPress bootstrap — confirmed the date-range inputs render with the correct sanitized values and the underlying `WP_Query` gets the correct `date_query`/`meta_key`/`meta_value` set
- [x] No plugin-related entries in `php_error_log` after activation and all of the above requests