### PR TITLE
Fix: miscellaneous WPCS hardening (JSON, timestamps, encoding, enqueue)

### DIFF
--- a/admin/class-awsm-job-openings-info.php
+++ b/admin/class-awsm-job-openings-info.php
@@ -153,7 +153,7 @@ class AWSM_Job_Openings_Info {
 			?>
 			<script>
 			jQuery(document).ready(function($) {
-				var emptyContent = <?php echo json_encode( $empty_content ); ?>;
+				var emptyContent = <?php echo wp_json_encode( $empty_content ); ?>;
 				$('.wrap').html(emptyContent);
 			});
 			</script>

--- a/admin/class-awsm-job-openings-overview.php
+++ b/admin/class-awsm-job-openings-overview.php
@@ -269,7 +269,9 @@ class AWSM_Job_Openings_Overview {
 			$orderby = "{$wpdb->posts}.post_date DESC";
 		}
 
-		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// The %s/%d placeholders live inside $where/$join, built incrementally above alongside
+		// $values — the sniff can't see across that split, hence both ignores below.
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 		$results = $wpdb->get_results( $wpdb->prepare( "SELECT {$wpdb->posts}.ID, COUNT(DISTINCT applications.ID) AS applications_count FROM {$wpdb->posts} {$join} {$where} GROUP BY {$wpdb->posts}.ID ORDER BY {$orderby}", $values ), OBJECT );
 
 		// Remove jobs whose application limit has been exceeded (pro pack hooks awsm_jobs_active_count_ids).

--- a/admin/templates/meta/job-status.php
+++ b/admin/templates/meta/job-status.php
@@ -71,9 +71,11 @@ if ( $post->post_type === 'awsm_job_application' ) {
 		}
 
 		if ( $post_count > 0 ) {
-			$applications                    = array_values( $applications );
-			$edit_link                       = get_edit_post_link( $applications[0] );
-			$data_rows['last_submission'][1] = sprintf( '<a href="%1$s">%2$s %3$s</a>', esc_url( $edit_link ? $edit_link : '' ), esc_html( human_time_diff( get_the_time( 'U', $applications[0] ), current_time( 'timestamp' ) ) ), esc_html__( 'ago', 'wp-job-openings' ) );
+			$applications = array_values( $applications );
+			$edit_link    = get_edit_post_link( $applications[0] );
+			// get_the_time( 'U' ) and current_time( 'timestamp' ) both use the site's local-offset
+			// convention (neither is true UTC), so they stay consistent with each other here.
+			$data_rows['last_submission'][1] = sprintf( '<a href="%1$s">%2$s %3$s</a>', esc_url( $edit_link ? $edit_link : '' ), esc_html( human_time_diff( get_the_time( 'U', $applications[0] ), current_time( 'timestamp' ) ) ), esc_html__( 'ago', 'wp-job-openings' ) ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
 		} else {
 			$data_rows['last_submission'][1] = esc_html__( 'NA', 'wp-job-openings' );
 		}

--- a/admin/templates/meta/resume-preview.php
+++ b/admin/templates/meta/resume-preview.php
@@ -40,7 +40,7 @@ do_action( 'awsm_resume_preview_mb_init', $post->ID );
 					</iframe>
 				<?php elseif ( in_array( $file_extension, array( 'doc', 'docx', 'ppt', 'pptx', 'xls', 'xlsx' ) ) ) : ?>
 					<iframe
-						data-src="<?php echo esc_url( 'https://view.officeapps.live.com/op/embed.aspx?src=' . urlencode( $attachment_url ) ); ?>"
+						data-src="<?php echo esc_url( 'https://view.officeapps.live.com/op/embed.aspx?src=' . rawurlencode( $attachment_url ) ); ?>"
 						class="awsm-preview-frame"
 						style="width: 100%; height: 400px; border: none;"
 						frameborder="0">

--- a/admin/templates/overview/main.php
+++ b/admin/templates/overview/main.php
@@ -252,8 +252,10 @@ if ( get_transient( '_awsm_add_ons_data' ) === false ) {
 						setup_postdata( $post );
 						$avatar = apply_filters( 'awsm_applicant_photo', get_avatar( $applicant_email, 36 ) );
 						wp_reset_postdata();
-						$edit_link       = AWSM_Job_Openings::get_application_edit_link( $application->ID );
-						$submission_time = human_time_diff( get_the_time( 'U', $application->ID ), current_time( 'timestamp' ) ) . ' ' . __( 'ago', 'wp-job-openings' );
+						$edit_link = AWSM_Job_Openings::get_application_edit_link( $application->ID );
+						// get_the_time( 'U' ) and current_time( 'timestamp' ) both use the site's local-offset
+						// convention (neither is true UTC), so they stay consistent with each other here.
+						$submission_time = human_time_diff( get_the_time( 'U', $application->ID ), current_time( 'timestamp' ) ) . ' ' . __( 'ago', 'wp-job-openings' ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
 						?>
 						<?php $is_unviewed = 'publish' === $application->post_status && get_post_meta( $application->ID, 'awsm_application_viewed', true ) === '0'; ?>
 					<a href="<?php echo esc_url( $edit_link ); ?>" class="awsm-jobs-overview-list-item<?php echo $is_unviewed ? ' awsm-overview-unviewed' : ''; ?>">

--- a/admin/templates/overview/widgets/recent-applications.php
+++ b/admin/templates/overview/widgets/recent-applications.php
@@ -31,7 +31,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 					$applicant_email = get_post_meta( $application->ID, 'awsm_applicant_email', true );
 					$avatar          = apply_filters( 'awsm_applicant_photo', get_avatar( $applicant_email, 32 ), $application->ID );
 					$edit_link       = AWSM_Job_Openings::get_application_edit_link( $application->ID );
-					$submission_time = human_time_diff( get_the_time( 'U', $application->ID ), current_time( 'timestamp' ) ) . ' ' . __( 'ago', 'wp-job-openings' );
+					// get_the_time( 'U' ) and current_time( 'timestamp' ) both use the site's local-offset
+					// convention (neither is true UTC), so they stay consistent with each other here.
+					$submission_time = human_time_diff( get_the_time( 'U', $application->ID ), current_time( 'timestamp' ) ) . ' ' . __( 'ago', 'wp-job-openings' ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
 					?>
 						<tr>
 							<td>

--- a/inc/class-awsm-job-openings-form.php
+++ b/inc/class-awsm-job-openings-form.php
@@ -1223,11 +1223,13 @@ class AWSM_Job_Openings_Form {
 					// The JS executeRecaptcha() calls grecaptcha.execute(siteKey,{action})
 					// which is a v3 API method — it requires the v3 script URL regardless
 					// of which recaptcha subtype the admin selected.
+					// null version is intentional: this is Google's externally-hosted, self-versioned
+					// script, not a local asset — we don't control its cache-busting.
 					wp_enqueue_script(
 						'awsm-jobs-g-recaptcha',
 						esc_url( "https://www.google.com/recaptcha/api.js?render={$site_key}" ),
 						array(),
-						null,
+						null, // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 						array(
 							'in_footer' => false,
 							'strategy'  => 'defer',
@@ -1260,11 +1262,13 @@ class AWSM_Job_Openings_Form {
 		// Generic path: v2_checkbox, hcaptcha, turnstile.
 		$script = apply_filters( 'awsm_jobs_captcha_script_config', $script, $captcha_type );
 
+		// null version is intentional: all of the built-in providers here are externally-hosted,
+		// self-versioned scripts, not local assets — we don't control their cache-busting.
 		wp_enqueue_script(
 			$script['handle'],
 			$script['src'],
 			isset( $script['deps'] ) ? $script['deps'] : array(),
-			null,
+			null, // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 			array(
 				'in_footer' => $script['in_footer'],
 				'strategy'  => $script['strategy'],

--- a/wp-job-openings.php
+++ b/wp-job-openings.php
@@ -241,13 +241,18 @@ class AWSM_Job_Openings {
 	}
 
 	public static function log( $data, $prefix = '' ) {
+		// Dedicated debug logging utility, gated behind WP_DEBUG_LOG and this plugin's own
+		// AWSM_JOBS_DEBUG constant (both must be explicitly opted into) — not a stray debug
+		// statement left in by mistake.
+		// phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_error_log
 		if ( defined( 'WP_DEBUG' ) && WP_DEBUG && defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG && defined( 'AWSM_JOBS_DEBUG' ) && AWSM_JOBS_DEBUG ) {
 			if ( is_string( $data ) ) {
 				error_log( 'HireZoot:' . $prefix . ': ' . $data );
 			} else {
-				error_log( 'HireZoot:' . $prefix . ': ' . json_encode( $data, JSON_PRETTY_PRINT ) );
+				error_log( 'HireZoot:' . $prefix . ': ' . wp_json_encode( $data, JSON_PRETTY_PRINT ) );
 			}
 		}
+		// phpcs:enable WordPress.PHP.DevelopmentFunctions.error_log_error_log
 	}
 
 	private function register_default_settings() {
@@ -848,7 +853,10 @@ class AWSM_Job_Openings {
 				break;
 
 			case 'submission_time':
-				$submission = human_time_diff( get_the_time( 'U' ), current_time( 'timestamp' ) ) . ' ' . __( 'ago', 'wp-job-openings' );
+				// get_the_time( 'U' ) and current_time( 'timestamp' ) both use the site's local-offset
+				// convention (neither is true UTC), so they stay consistent with each other here; this
+				// is WordPress core's own pattern for "time ago" displays.
+				$submission = human_time_diff( get_the_time( 'U' ), current_time( 'timestamp' ) ) . ' ' . __( 'ago', 'wp-job-openings' ); // phpcs:ignore WordPress.DateTime.CurrentTimeTimestamp.Requested
 				echo esc_html( $submission );
 				break;
 		}
@@ -1504,7 +1512,7 @@ class AWSM_Job_Openings {
 				'form_error_msg' => array(
 					'general'         => esc_html__( 'Error in submitting your application. Please try again later!', 'wp-job-openings' ),
 					'file_validation' => esc_html__( 'The file you have selected is too large.', 'wp-job-openings' ),
-					'captcha_failed'  => esc_html__( 'reCAPTCHA failed to load. Please check your configuration.' ),
+					'captcha_failed'  => esc_html__( 'reCAPTCHA failed to load. Please check your configuration.', 'wp-job-openings' ),
 				),
 			),
 			'vendors'            => array(


### PR DESCRIPTION
## Summary
- `json_encode()` → `wp_json_encode()` for safer UTF-8/PHP-version handling (debug logger in `wp-job-openings.php`, inline script data in `admin/class-awsm-job-openings-info.php`).
- `urlencode()` → `rawurlencode()` when embedding a resume URL as a query-string value in the Office viewer iframe `src` (`resume-preview.php`) — RFC 3986 encoding is the correct choice here, not form-encoding.
- Documented and scoped-ignored 4 `current_time( 'timestamp' )` call sites (all `human_time_diff( get_the_time( 'U' ), current_time( 'timestamp' ) )` "time ago" displays) — both sides deliberately use WordPress's site-local-offset convention, matching core's own comment/application time-ago pattern. Switching to `time()` would introduce a real timezone bug, so I documented why instead of "fixing" it.
- Scoped-ignored 2 `wp_enqueue_script()` calls with a `null` version — both are externally-hosted captcha provider scripts (Google reCAPTCHA, and the generic hCaptcha/Turnstile path) whose versioning we don't control.
- Added the missing `'wp-job-openings'` text-domain argument to one `esc_html__()` call (reCAPTCHA failed-to-load message).
- Extended an existing `phpcs:ignore` to also cover `WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare` — a sniff-visibility limitation, not a real vulnerability, on a query whose placeholders are built incrementally into `$where`/`$join` across the function.

## Why
Each of these is a distinct, independently-reviewed PHPCS finding where the "obvious" fix would either be a no-op (json/urlencode swaps) or would actually introduce a bug (current_time). Bundling them together since none is large enough to warrant its own PR.

## Test Plan
- [x] `php -l` on all 8 touched files — no syntax errors
- [x] `vendor/bin/phpcs --report=summary .` — 0 errors, all targeted warnings resolved, no regressions
- [x] Live-verified all three "time ago" template displays (`job-status.php`, `overview/main.php`, `recent-applications.php`) plus the `submission_time` admin-list column in `wp-job-openings.php`, against a real WordPress install with a test application post dated 2 hours in the past — all four correctly rendered "2 hours ago"
- [x] Confirmed activating the plugin and loading the admin overview/job-status screens produces no plugin-related entries in `php_error_log`