### PR TITLE
Fix: route persistent config file writes through WP_Filesystem

### DIFF
--- a/admin/class-awsm-job-openings-meta.php
+++ b/admin/class-awsm-job-openings-meta.php
@@ -382,7 +382,11 @@ class AWSM_Job_Openings_Meta {
 				}
 
 				if ( is_readable( $file_details['file_name'] ) ) {
-					readfile( $file_details['file_name'] );
+					// is_readable() above already confirms this process can read the file directly;
+					// streaming it with readfile() (rather than buffering the whole file into memory
+					// via WP_Filesystem::get_contents(), or risking WP_Filesystem choosing an FTP
+					// transport to fetch a file we can already read locally) is the correct choice here.
+					readfile( $file_details['file_name'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_readfile
 				} else {
 					wp_die( esc_html__( 'File is not readable.', 'wp-job-openings' ) );
 				}

--- a/admin/class-awsm-job-openings-settings.php
+++ b/admin/class-awsm-job-openings-settings.php
@@ -959,10 +959,24 @@ class AWSM_Job_Openings_Settings {
 		if ( $value === 'hide_files' ) {
 			$file_content = 'deny from all';
 		}
-		$handle = @fopen( $file_name, 'w' );
-		if ( $handle ) {
-			fwrite( $handle, $file_content );
-			fclose( $handle );
+		global $wp_filesystem;
+		if ( ! $wp_filesystem ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+			if ( get_filesystem_method( array(), $upload_dir ) === 'direct' ) {
+				WP_Filesystem();
+			}
+		}
+		if ( $wp_filesystem ) {
+			$wp_filesystem->put_contents( $file_name, $file_content );
+		} else {
+			// Fall back to a direct write when WP_Filesystem needs credentials we don't have
+			// (e.g. a non-direct hosting setup) — matches this method's pre-existing best-effort
+			// behavior rather than silently doing nothing.
+			$handle = @fopen( $file_name, 'w' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen, WordPress.PHP.NoSilencedErrors.Discouraged
+			if ( $handle ) {
+				fwrite( $handle, $file_content ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+				fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+			}
 		}
 	}
 

--- a/inc/class-awsm-job-openings-core.php
+++ b/inc/class-awsm-job-openings-core.php
@@ -306,13 +306,27 @@ class AWSM_Job_Openings_Core {
 			),
 		);
 		if ( wp_mkdir_p( $upload_dir ) ) {
+			global $wp_filesystem;
+			if ( ! $wp_filesystem ) {
+				require_once ABSPATH . 'wp-admin/includes/file.php';
+				if ( get_filesystem_method( array(), $upload_dir ) === 'direct' ) {
+					WP_Filesystem();
+				}
+			}
 			foreach ( $files as $file ) {
 				$current_file = trailingslashit( $upload_dir ) . $file['name'];
 				if ( ! file_exists( $current_file ) ) {
-					$handle = @fopen( $current_file, 'w' );
-					if ( $handle ) {
-						fwrite( $handle, $file['content'] );
-						fclose( $handle );
+					if ( $wp_filesystem ) {
+						$wp_filesystem->put_contents( $current_file, $file['content'] );
+					} else {
+						// Fall back to a direct write when WP_Filesystem needs credentials we don't
+						// have (e.g. a non-direct hosting setup) — matches this method's pre-existing
+						// best-effort behavior rather than silently doing nothing.
+						$handle = @fopen( $current_file, 'w' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen, WordPress.PHP.NoSilencedErrors.Discouraged
+						if ( $handle ) {
+							fwrite( $handle, $file['content'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
+							fclose( $handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fclose
+						}
 					}
 				}
 			}

--- a/inc/class-awsm-job-openings-form.php
+++ b/inc/class-awsm-job-openings-form.php
@@ -386,7 +386,12 @@ class AWSM_Job_Openings_Form {
 				$index_php_file = $directory_path . '/index.php';
 				if ( ! file_exists( $index_php_file ) ) {
 					$index_php_content = "<?php\n\n//Silence is golden.\n";
-					file_put_contents( $index_php_file, $index_php_content );
+					// This runs on every public application submission with a file upload — a full
+					// WP_Filesystem init here would add real overhead (and, in the rare case it
+					// can't get direct access non-interactively, real fragility) to that hot,
+					// user-facing path for a directory the app-submission code path already just
+					// wrote the uploaded file into with the same permissions.
+					file_put_contents( $index_php_file, $index_php_content ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
 				}
 			}
 		}
@@ -1006,7 +1011,11 @@ class AWSM_Job_Openings_Form {
 							if ( ! empty( $admin_attachments ) ) {
 								foreach ( $admin_attachments as $admin_attachment ) {
 									if ( isset( $admin_attachment['temp'] ) && $admin_attachment['temp'] === true ) {
-										unlink( $admin_attachment['file'] );
+										// This process just created this temp file moments earlier in
+										// the same request, so it always has permission to remove it —
+										// a full WP_Filesystem init here would only add overhead on this
+										// hot (application-submission) path with no safety benefit.
+										unlink( $admin_attachment['file'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
 									}
 								}
 							}

--- a/inc/helper-functions.php
+++ b/inc/helper-functions.php
@@ -52,8 +52,12 @@ if ( ! function_exists( 'get_awsm_jobs_time_format' ) ) {
 
 if ( ! function_exists( 'awsm_jobs_is_valid_template_file' ) ) {
 	function awsm_jobs_is_valid_template_file( $filename, $unsupported_versions = array() ) {
-		$is_valid         = true;
-		$template_content = @file_get_contents( $filename );
+		$is_valid = true;
+		// Read-only check of a bundled/theme-overridden template's header, called on the
+		// notification-email send path — kept as a lightweight direct read rather than a full
+		// WP_Filesystem init (which adds real overhead and offers no benefit for reading a
+		// plugin/theme-controlled local path).
+		$template_content = @file_get_contents( $filename ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, WordPress.PHP.NoSilencedErrors.Discouraged
 		if ( ! empty( $template_content ) ) {
 			if ( strpos( $template_content, '@version' ) === false ) {
 				$is_valid = false;

--- a/wp-job-openings.php
+++ b/wp-job-openings.php
@@ -337,7 +337,21 @@ class AWSM_Job_Openings {
 	public function index_to_upload_dir( $dir ) {
 		$index_file = $dir . '/index.php';
 		if ( ! file_exists( $index_file ) ) {
-			file_put_contents( $index_file, "<?php\n\n//Silence is golden.\n" );
+			global $wp_filesystem;
+			if ( ! $wp_filesystem ) {
+				require_once ABSPATH . 'wp-admin/includes/file.php';
+				if ( get_filesystem_method( array(), $dir ) === 'direct' ) {
+					WP_Filesystem();
+				}
+			}
+			if ( $wp_filesystem ) {
+				$wp_filesystem->put_contents( $index_file, "<?php\n\n//Silence is golden.\n" );
+			} else {
+				// Fall back to a direct write when WP_Filesystem needs credentials we don't have
+				// (e.g. a non-direct hosting setup) — matches this method's pre-existing
+				// best-effort behavior rather than silently doing nothing.
+				file_put_contents( $index_file, "<?php\n\n//Silence is golden.\n" ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			}
 		}
 		$sub_dirs = array_filter( glob( $dir . '/*' ), 'is_dir' );
 		foreach ( $sub_dirs as $sub_dir ) {


### PR DESCRIPTION
## Summary
Converts the 3 sites that write persistent directory-protection files (`.htaccess`, `index.html`/`index.php` in the uploads directory — during activation, the one-time upgrade routine, and the "hide uploaded files" settings toggle) from raw `fopen()`/`fwrite()`/`fclose()`/`file_put_contents()` to `WP_Filesystem`, matching the class of write `WP_Filesystem` exists to protect and the `get_filesystem_method()` check this codebase already uses elsewhere (`admin/class-awsm-job-openings-info.php`). Each conversion keeps a fallback to the original direct-write code when `WP_Filesystem` can't get non-interactive "direct" access, so behavior is unchanged on any host where it was already working.

For the remaining 4 direct-filesystem-call warnings, I added scoped ignores with rationale instead of converting, since a full `WP_Filesystem` init would add real overhead (or, on non-direct hosts, real fragility) with no benefit:
- **`inc/helper-functions.php`**: a read-only template-header check on the notification-email send path.
- **`inc/class-awsm-job-openings-form.php` (×2)**: a temp-file `unlink()` and an `index.php` write on the *public* application-submission path — both touch a file this same process just created/uploaded moments earlier, so `WP_Filesystem`'s permission model offers nothing raw PHP doesn't already have here.
- **`admin/class-awsm-job-openings-meta.php`**: the resume/attachment `readfile()` download stream, already gated behind `is_readable()` — buffering the whole file via `WP_Filesystem::get_contents()` would trade streaming for memory usage with no security benefit.

## Why
The blanket "use WP_Filesystem" recommendation is right for persistent config writes but wrong for hot, high-frequency paths or reads of files the process already has guaranteed access to — this PR draws that line explicitly rather than converting everything mechanically.

## Test Plan
- [x] `php -l` on all 6 touched files — no syntax errors
- [x] `vendor/bin/phpcs --report=summary .` — 0 errors, all targeted `file_system_operations`/`file_get_contents`/`file_put_contents`/`unlink` warnings resolved
- [x] Caught and fixed a real bug during testing: `get_filesystem_method()` was being called *before* requiring `wp-admin/includes/file.php` (the file that defines it) in all 3 conversions — reordered so the require always runs first
- [x] Live-exercised all 3 converted methods against a real WordPress install: `create_upload_directory()` (writes correct `index.html`/`.htaccess` content, confirmed `$wp_filesystem` resolves to `WP_Filesystem_Direct`), `update_awsm_hide_uploaded_files()` (toggled both directions, correct `.htaccess` content each time), and `index_to_upload_dir()` (recursive `index.php` writes into a subdirectory, correct content)
- [x] No plugin-related entries in `php_error_log` after all of the above