### PR TITLE
Fix: rename reserved-keyword parameters, document required-but-unused ones

### DIFF
--- a/admin/class-awsm-job-openings-meta.php
+++ b/admin/class-awsm-job-openings-meta.php
@@ -104,7 +104,9 @@ class AWSM_Job_Openings_Meta {
 		wp_nonce_field( 'awsm_save_post_meta', 'awsm_jobs_posts_nonce' );
 	}
 
-	public function awsm_job_status( $post ) {
+	// $post is used by templates/meta/job-status.php via PHP's include-shared local scope, not
+	// referenced directly in this method body.
+	public function awsm_job_status( $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		include $this->cpath . '/templates/meta/job-status.php';
 	}
 
@@ -143,15 +145,21 @@ class AWSM_Job_Openings_Meta {
 		wp_send_json_success( array( 'html' => $html ) );
 	}
 
-	public function awsm_job_handle( $post ) {
+	// $post is used by templates/meta/job-specifications.php via PHP's include-shared local
+	// scope, not referenced directly in this method body.
+	public function awsm_job_handle( $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		include $this->cpath . '/templates/meta/job-specifications.php';
 	}
 
-	public function awsm_job_expiration( $post ) {
+	// $post is used by templates/meta/job-expiry.php via PHP's include-shared local scope, not
+	// referenced directly in this method body.
+	public function awsm_job_expiration( $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		include $this->cpath . '/templates/meta/job-expiry.php';
 	}
 
-	public function awsm_job_application_handle( $post ) {
+	// $post is used by templates/meta/applicant-single.php via PHP's include-shared local scope,
+	// not referenced directly in this method body.
+	public function awsm_job_application_handle( $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		include $this->cpath . '/templates/meta/applicant-single.php';
 	}
 
@@ -170,7 +178,9 @@ class AWSM_Job_Openings_Meta {
 		}
 	}
 
-	public function application_actions_meta_handler( $post ) {
+	// $post is used by templates/meta/application-actions.php via PHP's include-shared local
+	// scope, not referenced directly in this method body.
+	public function application_actions_meta_handler( $post ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		include $this->cpath . '/templates/meta/application-actions.php';
 	}
 
@@ -198,7 +208,10 @@ class AWSM_Job_Openings_Meta {
 		return apply_filters( 'awsm_jobs_opening_applicant_single_tab_list', $tab_list );
 	}
 
-	public static function get_applicant_single_view_content( $post_id, $attachment_id ) {
+	// $attachment_id is part of this method's public signature (called with it from
+	// templates/meta/applicant-single.php) but isn't currently forwarded to the filter below;
+	// changing that filter's signature is a cross-plugin-hook decision outside this cleanup's scope.
+	public static function get_applicant_single_view_content( $post_id, $attachment_id ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		$tab_content = array();
 		return apply_filters( 'awsm_jobs_opening_applicant_single_view_content', $tab_content, $post_id );
 	}
@@ -441,7 +454,7 @@ class AWSM_Job_Openings_Meta {
 		return $new_status;
 	}
 
-	public function awsm_add_unread_application_class( $classes, $class, $post_id ) {
+	public function awsm_add_unread_application_class( $classes, $extra_class, $post_id ) {
 		if ( get_post_type( $post_id ) === 'awsm_job_application' ) {
 			$post_status = get_post_status( $post_id );
 

--- a/admin/class-awsm-job-openings-settings.php
+++ b/admin/class-awsm-job-openings-settings.php
@@ -40,7 +40,9 @@ class AWSM_Job_Openings_Settings {
 		return self::$instance;
 	}
 
-	public function settings_page_capability( $capability ) {
+	// $capability is part of the option_page_capability_{group} filter's fixed signature; this
+	// callback always overrides it, regardless of the incoming value.
+	public function settings_page_capability( $capability ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
 		return 'manage_awsm_jobs';
 	}
 
@@ -1009,13 +1011,13 @@ class AWSM_Job_Openings_Settings {
 		wp_die();
 	}
 
-	public function is_settings_field_checked( $option, $value, $default = false ) {
+	public function is_settings_field_checked( $option, $value, $default_value = false ) {
 		$checked = '';
 		if ( ! empty( $option ) ) {
 			if ( $option === $value ) {
 				$checked = 'checked';
 			}
-		} elseif ( $default ) {
+		} elseif ( $default_value ) {
 				$checked = 'checked';
 		}
 		return $checked;
@@ -1092,7 +1094,7 @@ class AWSM_Job_Openings_Settings {
 		<?php
 	}
 
-	public function display_settings_fields( $settings_fields, $container = 'table', $echo = true ) {
+	public function display_settings_fields( $settings_fields, $container = 'table', $display = true ) {
 		$content = '';
 		if ( ! empty( $settings_fields ) && is_array( $settings_fields ) ) {
 			$allowed_html = array(
@@ -1384,7 +1386,7 @@ class AWSM_Job_Openings_Settings {
 		 * @param string $container Container for settings fields
 		 */
 		$content = apply_filters( 'awsm_jobs_settings_fields_content', $content, $settings_fields, $container );
-		if ( $echo === true ) {
+		if ( $display === true ) {
 			echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		} else {
 			return $content;

--- a/blocks/class-awsm-job-guten-blocks.php
+++ b/blocks/class-awsm-job-guten-blocks.php
@@ -34,7 +34,9 @@ class Awsm_Job_Guten_Blocks {
 		register_block_type( __DIR__ . '/build', $args );
 	}
 
-	public function block_render_callback( $atts, $content ) {
+	// $content is part of the Gutenberg render_callback's fixed signature (attributes, content,
+	// block); this dynamic block ignores the inner block content and renders from $atts alone.
+	public function block_render_callback( $atts, $content ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 
 		if ( ! isset( $atts['filter_options'] ) || ! is_array( $atts['filter_options'] ) ) {
 			$atts['filter_options'] = array();

--- a/inc/class-awsm-job-openings-block.php
+++ b/inc/class-awsm-job-openings-block.php
@@ -328,8 +328,8 @@ class AWSM_Job_Openings_Block {
 		$query = new WP_Query( $args );
 
 		$ajax_button_style        = ! empty( $attributes['hz_button_style'] ) ? sanitize_key( $attributes['hz_button_style'] ) : 'none';
-		$ajax_button_style_filter = function ( $class ) use ( $ajax_button_style ) {
-			return $class . ' is-button-' . $ajax_button_style;
+		$ajax_button_style_filter = function ( $css_class ) use ( $ajax_button_style ) {
+			return $css_class . ' is-button-' . $ajax_button_style;
 		};
 		add_filter( 'awsm_b_job_more_button_class', $ajax_button_style_filter );
 

--- a/inc/class-awsm-job-openings-form.php
+++ b/inc/class-awsm-job-openings-form.php
@@ -1274,7 +1274,8 @@ class AWSM_Job_Openings_Form {
 		if ( ! empty( $script['async'] ) ) {
 			add_filter(
 				'script_loader_tag',
-				function ( $tag, $handle, $src ) use ( $config ) {
+				// $src is part of the script_loader_tag filter's fixed signature; unused here.
+				function ( $tag, $handle, $src ) use ( $config ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 					$captcha_handles = array();
 					foreach ( $config as $type => $captcha_config ) {
 						if ( isset( $captcha_config['script']['handle'] ) && ! empty( $captcha_config['script']['async'] ) ) {

--- a/inc/helper-functions.php
+++ b/inc/helper-functions.php
@@ -84,11 +84,11 @@ if ( ! function_exists( 'awsm_jobs_get_original_image_url' ) ) {
 }
 
 if ( ! function_exists( 'awsm_jobs_array_flatten' ) ) {
-	function awsm_jobs_array_flatten( $array ) {
+	function awsm_jobs_array_flatten( $items ) {
 		$result = array();
-		if ( is_array( $array ) ) {
+		if ( is_array( $items ) ) {
 			array_walk_recursive(
-				$array,
+				$items,
 				function ( $item ) use ( &$result ) {
 					$result[] = $item;
 				}

--- a/inc/template-functions-block.php
+++ b/inc/template-functions-block.php
@@ -11,12 +11,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 if ( ! function_exists( 'awsm_block_jobs_view_class' ) ) {
-	function awsm_block_jobs_view_class( $class = '', $attributes = array() ) {
+	function awsm_block_jobs_view_class( $css_class = '', $attributes = array() ) {
 		$view_class = AWSM_Job_Openings_Block::get_job_listing_view_class_block( $attributes );
 
 		// Merge custom class with view class if present
-		if ( ! empty( $class ) ) {
-			$view_class = trim( "$view_class $class" );
+		if ( ! empty( $css_class ) ) {
+			$view_class = trim( "$view_class $css_class" );
 		}
 
 		// Only return the class attribute if there's a class to output
@@ -202,7 +202,7 @@ if ( ! function_exists( 'awsm_block_jobs_paginate_links' ) ) {
 }
 
 if ( ! function_exists( 'awsm_jobs_block_featured_image' ) ) {
-	function awsm_jobs_block_featured_image( $echo = true, $size = 'thumbnail', $attr = '', $block_atts = array() ) {
+	function awsm_jobs_block_featured_image( $display = true, $size = 'thumbnail', $attr = '', $block_atts = array() ) {
 		$content                = '';
 		$post_thumbnail_id      = get_post_thumbnail_id();
 		$featured_image_support = get_option( 'awsm_jobs_enable_featured_image' );
@@ -221,7 +221,7 @@ if ( ! function_exists( 'awsm_jobs_block_featured_image' ) ) {
 		if ( ! empty( $content ) ) {
 			$content = '<div class="awsm-job-featured-image">' . $content . '</div>';
 		}
-		if ( $echo ) {
+		if ( $display ) {
 			echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		} else {
 			return $content;
@@ -236,14 +236,14 @@ if ( ! function_exists( 'awsm_block_job_listing_spec_content' ) ) {
 }
 
 if ( ! function_exists( 'awsm_jobs_block_listing_item_class' ) ) {
-	function awsm_jobs_block_listing_item_class( $class = array() ) {
+	function awsm_jobs_block_listing_item_class( $extra_classes = array() ) {
 		$job_id  = get_the_ID();
 		$classes = array( 'awsm-b-job-listing-item' );
 		if ( is_awsm_job_expired() ) {
 			$classes[] = 'awsm-b-job-expired-item';
 		}
-		if ( ! empty( $class ) ) {
-			$classes = array_merge( $classes, $class );
+		if ( ! empty( $extra_classes ) ) {
+			$classes = array_merge( $classes, $extra_classes );
 		}
 		/**
 		 * Filters the classes for each job listing item.

--- a/inc/template-functions.php
+++ b/inc/template-functions.php
@@ -96,7 +96,7 @@ if ( ! function_exists( 'awsm_jobs_view' ) ) {
 }
 
 if ( ! function_exists( 'awsm_jobs_wrapper_class' ) ) {
-	function awsm_jobs_wrapper_class( $echo = true ) {
+	function awsm_jobs_wrapper_class( $display = true ) {
 		$wrapper_class = '';
 		$form_style    = get_option( 'awsm_jobs_form_style', 'theme' );
 		if ( $form_style === 'plugin' ) {
@@ -110,7 +110,7 @@ if ( ! function_exists( 'awsm_jobs_wrapper_class' ) ) {
 		 * @param string $wrapper_class Class names.
 		 */
 		$wrapper_class = apply_filters( 'awsm_jobs_wrapper_class', $wrapper_class );
-		if ( $echo ) {
+		if ( $display ) {
 			echo esc_attr( $wrapper_class );
 		} else {
 			return $wrapper_class;
@@ -119,24 +119,24 @@ if ( ! function_exists( 'awsm_jobs_wrapper_class' ) ) {
 }
 
 if ( ! function_exists( 'awsm_jobs_view_class' ) ) {
-	function awsm_jobs_view_class( $class = '', $shortcode_atts = array() ) {
+	function awsm_jobs_view_class( $css_class = '', $shortcode_atts = array() ) {
 		$view_class = AWSM_Job_Openings::get_job_listing_view_class( $shortcode_atts );
-		if ( ! empty( $class ) ) {
-			$view_class = trim( $view_class . ' ' . $class );
+		if ( ! empty( $css_class ) ) {
+			$view_class = trim( $view_class . ' ' . $css_class );
 		}
 		printf( 'class="%s"', esc_attr( $view_class ) );
 	}
 }
 
 if ( ! function_exists( 'awsm_jobs_listing_item_class' ) ) {
-	function awsm_jobs_listing_item_class( $class = array() ) {
+	function awsm_jobs_listing_item_class( $extra_classes = array() ) {
 		$job_id  = get_the_ID();
 		$classes = array( 'awsm-job-listing-item' );
 		if ( is_awsm_job_expired() ) {
 			$classes[] = 'awsm-job-expired-item';
 		}
-		if ( ! empty( $class ) ) {
-			$classes = array_merge( $classes, $class );
+		if ( ! empty( $extra_classes ) ) {
+			$classes = array_merge( $classes, $extra_classes );
 		}
 		/**
 		 * Filters the classes for each job listing item.
@@ -167,10 +167,10 @@ if ( ! function_exists( 'awsm_jobs_data_attrs' ) ) {
 }
 
 if ( ! function_exists( 'awsm_job_content_class' ) ) {
-	function awsm_job_content_class( $class = '' ) {
+	function awsm_job_content_class( $css_class = '' ) {
 		$content_class = 'awsm-job-single-wrap' . awsm_jobs_wrapper_class( false ) . AWSM_Job_Openings::get_job_details_class();
-		if ( ! empty( $class ) ) {
-			$content_class .= ' ' . $class;
+		if ( ! empty( $css_class ) ) {
+			$content_class .= ' ' . $css_class;
 		}
 		printf( 'class="%s"', esc_attr( $content_class ) );
 	}
@@ -367,7 +367,7 @@ if ( ! function_exists( 'awsm_job_form_submit_btn' ) ) {
 }
 
 if ( ! function_exists( 'awsm_jobs_featured_image' ) ) {
-	function awsm_jobs_featured_image( $echo = true, $size = 'thumbnail', $attr = '' ) {
+	function awsm_jobs_featured_image( $display = true, $size = 'thumbnail', $attr = '' ) {
 		$content                = '';
 		$post_thumbnail_id      = get_post_thumbnail_id();
 		$featured_image_support = get_option( 'awsm_jobs_enable_featured_image' );
@@ -386,7 +386,7 @@ if ( ! function_exists( 'awsm_jobs_featured_image' ) ) {
 		if ( ! empty( $content ) ) {
 			$content = '<div class="awsm-job-featured-image">' . $content . '</div>';
 		}
-		if ( $echo ) {
+		if ( $display ) {
 			echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		} else {
 			return $content;

--- a/inc/templates/block-files/block-job-openings-view.php
+++ b/inc/templates/block-files/block-job-openings-view.php
@@ -132,8 +132,8 @@ if ( $has_search || $has_filters || $has_alerts ) {
 }
 
 $button_style        = ! empty( $styles['button_style'] ) ? $styles['button_style'] : 'none';
-$button_style_filter = function ( $class ) use ( $button_style ) {
-	return $class . ' is-button-' . $button_style;
+$button_style_filter = function ( $css_class ) use ( $button_style ) {
+	return $css_class . ' is-button-' . $button_style;
 };
 add_filter( 'awsm_b_job_more_button_class', $button_style_filter );
 

--- a/wp-job-openings.php
+++ b/wp-job-openings.php
@@ -2489,14 +2489,14 @@ class AWSM_Job_Openings {
 		/** Filters the job specifications content. */
 		return apply_filters( 'awsm_job_specs_content', $spec_content, $post_id );
 	}
-	public static function display_specifications_content( $post_id, $pos, $echo = true ) {
+	public static function display_specifications_content( $post_id, $pos, $display = true ) {
 		$content       = '';
 		$show_job_spec = get_option( 'awsm_jobs_specification_job_detail', 'show_in_detail' );
 		$spec_position = get_option( 'awsm_jobs_specs_position', 'below_content' );
 		if ( $spec_position === $pos && $show_job_spec === 'show_in_detail' ) {
 			$content = sprintf( '<div class="awsm-job-specifications-container %2$s"><div class="awsm-job-specifications-row">%1$s</div></div>', self::get_specifications_content( $post_id, true ), esc_attr( 'awsm_job_spec_' . $pos ) );
 		}
-		if ( $echo ) {
+		if ( $display ) {
 			echo $content; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		} else {
 			return $content;


### PR DESCRIPTION
## Summary
Renames 15 function/method/closure parameters named after PHP reserved keywords (`$class`, `$echo`, `$array`, `$default`) to descriptive names (`$css_class`, `$extra_class(es)`, `$display`, `$items`, `$default_value`). Parameter names are never part of a PHP call's contract (only position/count matters, including for WordPress's positional hook callbacks), so this is a pure rename with no behavior change — verified no named-argument-style calls exist anywhere in the codebase.

Also resolves the 9 unused-function-parameter warnings, **none by removing the parameter**:
- 5 `admin/class-awsm-job-openings-meta.php` metabox-callback methods (`awsm_job_status`, `awsm_job_handle`, `awsm_job_expiration`, `awsm_job_application_handle`, `application_actions_meta_handler`) pass `$post` to an `include()`'d template that uses it via PHP's shared local scope — invisible to static analysis, but a real use.
- `get_applicant_single_view_content()`'s `$attachment_id` is part of its public signature (called with it from `applicant-single.php`) but isn't forwarded to the `awsm_jobs_opening_applicant_single_view_content` filter — documented rather than silently changing that filter's signature, which is a cross-plugin-hook decision outside this cleanup's scope.
- The remaining 3 (`script_loader_tag` closure's `$src`, `settings_page_capability`'s `$capability`, the Gutenberg block's `render_callback`'s `$content`) are all fixed positions in WordPress core hook/callback signatures.

## Why
Every rename/ignore was checked against how the parameter is actually used (or required to be present) before touching it — none of these are blind mechanical fixes.

## Test Plan
- [x] `php -l` on all 10 touched files — no syntax errors
- [x] `vendor/bin/phpcs --report=summary .` — 0 errors, all 24 targeted warnings resolved, no regressions
- [x] Grepped the whole codebase for named-argument-style calls (`name: value`) to any renamed function — none found
- [x] Live-exercised the renamed template-tag functions against a real WordPress install: `awsm_jobs_array_flatten()` (nested array flattening), `awsm_jobs_wrapper_class()`/`awsm_jobs_view_class()`/`awsm_jobs_listing_item_class()` (both echo and return modes, extra-class merging) — all produced correct output
- [x] Live-exercised `awsm_add_unread_application_class()` (the `post_class` filter callback) and `is_settings_field_checked()` with real post data — both produced correct results
- [x] Confirmed the public job listing archive still loads (200, no plugin-related `php_error_log` entries)