### PR TITLE
Fix: WordPress.org Plugin Check (PCP) directory-compliance findings

### DIFF
--- a/inc/templates/theme-compat/footer.php
+++ b/inc/templates/theme-compat/footer.php
@@ -9,6 +9,9 @@
  * @version 3.2.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 ?>
 		</div><!-- #content -->
 	</div><!-- #page -->

--- a/inc/templates/theme-compat/header.php
+++ b/inc/templates/theme-compat/header.php
@@ -9,6 +9,9 @@
  * @version 3.2.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 ?>
 
 <!DOCTYPE html>

--- a/wp-job-openings.php
+++ b/wp-job-openings.php
@@ -1380,7 +1380,7 @@ class AWSM_Job_Openings {
 
 	public function plugin_rating_notice_handler() {
 		$rating_env = apply_filters( 'awsm_jobs_plugin_rating_env', 'WordPress' );
-		$rating_url = apply_filters( 'awsm_jobs_plugin_rating_url', 'https://wordpress.org/support/plugin/wp-job-openings/reviews/?filter=5' );
+		$rating_url = apply_filters( 'awsm_jobs_plugin_rating_url', 'https://wordpress.org/support/plugin/wp-job-openings/reviews/' );
 
 		$rated = intval( get_option( 'awsm_jobs_plugin_rating' ) );
 		if ( $rated !== 1 ) {


### PR DESCRIPTION
## Summary
- Removes the direct link to 5-star-filtered reviews (`reviews/?filter=5` → `reviews/`), which the WordPress.org plugin directory guidelines explicitly disallow as a form of review manipulation.
- Adds the standard direct-access guard (`if ( ! defined( 'ABSPATH' ) ) exit;`) to the two theme-compat template files that shipped without one (`inc/templates/theme-compat/header.php`, `footer.php`) — every other template file in this plugin already has this guard.

## Why
I ran the actual Plugin Check tool (via WP-CLI's `wp plugin check`, not just this repo's own `phpcs.xml`) against a combined build of all pending PHPCS/security PRs, to see what PCP flags that our own ruleset doesn't catch. Most of what it additionally reported turned out to be false positives worth recording rather than fixing:
- **`trademarked_term`** (the "wp" in the plugin slug) — this plugin predates that directory rule; renaming the slug now would break every existing install's update path, so this is grandfathered, not a bug.
- **`mismatched_plugin_name`** (readme.txt's longer marketing title vs. the plugin header's short one) — a branding decision, not a code fix; flagging for the maintainers rather than picking one unilaterally.
- ~12 **`TextDomainMismatch`** warnings are all `__( ..., 'default' )` calls that intentionally reuse WordPress core's own translated strings (e.g. "Custom field updated.") — correct, deliberate practice.
- **`application_detected`** on `phpstan.neon.dist`, and the hidden-file/directory findings on dotfiles and tooling directories — packaging-tool false positives on dev-only files already excluded from the distributed zip via `.gitattributes` `export-ignore`.
- A DB-parameter "unescaped" warning in `admin/class-awsm-job-openings-overview.php` — false positive; the value is already cast to `(int)` before being interpolated into the query.
- ~55 **`ValidatedSanitizedInput`** (missing `wp_unslash()`/sanitization) findings across 10 files, and 10 **`NonPrefixedFunctionFound`** findings (global functions like `is_awsm_job_expired()` that don't literally start with the registered prefix) are real but **out of scope for this PR** — the former is sizable enough to warrant its own dedicated review pass, and the latter would need deprecated-wrapper shims to avoid breaking anything calling these functions by name today. Flagging both for a decision on whether/how to proceed.

## Test Plan
- [x] `php -l` on all 3 touched files — no syntax errors
- [x] `vendor/bin/phpcs --report=summary .` — 0 errors, no regressions
- [x] Live-verified the plugin still activates and the public job listing archive loads (200, no plugin-related `php_error_log` entries)